### PR TITLE
sellerCountry in CSV

### DIFF
--- a/multiProcess.py
+++ b/multiProcess.py
@@ -152,7 +152,7 @@ def multiMap(url_list, pool_size, out_file, stat_file, signals, no_proxies_max, 
     csv_writer = csv.writer(opened_outFile)
     csv_writer.writerow(
         ['attribute', 'game', 'item', 'extension', 'number', 'name', 'min_price', 'price_trend', 'mean30d_price',
-         'language', 'sellerType', 'minCondition', 'isSigned', 'isFirstEd', 'isPlayset', 'isAltered', 'isReverseHolo',
+         'language', 'sellerCountry', 'sellerType', 'minCondition', 'isSigned', 'isFirstEd', 'isPlayset', 'isAltered', 'isReverseHolo',
          'isFoil', 'url'])
 
     currentText = "Starting multithreading for scraping ..."

--- a/scrapers.py
+++ b/scrapers.py
@@ -46,7 +46,7 @@ def CMSoupScraper(url, soup):
 
 		# If there are no parameters, return none.
 		if params_ref == '':
-			l = ["None"] * 9
+			l = ["None"] * 10
 			return l
 
 		# get the list of all the parameters in the url


### PR DESCRIPTION
Added sellerCountry column to CSV in order to fix issues when scraping multiple parameters. 
Added another column when scraping page without parameters.

When trying to scrape a link like this
`https://www.cardmarket.com/de/Pokemon/Products/Singles/Fossil/Haunter-V1-FO6?language=3&minCondition=4&isFirstEd=N`
the columns in the CSV are messed up because there is one missing, which is sellerCountry.

A link without parameters like this
`https://www.cardmarket.com/de/Pokemon/Products/Singles/Neo-Destiny/Shining-Charizard-NDE107`
seems to work fine, but is in fact missing a column. This is why the multiplier of the "None" string in scrapers.py has to be increased from 9 to 10. After the prices there are 10 parameters.

On the first screenshot you can see that the second record is off. minCondition should be "4" and not "None". isSigned should be "None" and not "4" and so on. On the second screenshot you can see the output with the fixed version.

<img width="1373" alt="Bildschirm­foto 2023-01-09 um 16 08 59" src="https://user-images.githubusercontent.com/122253264/211340518-75f0564d-e5a6-4bb1-a7bd-6f036f11fa09.png">

<img width="1409" alt="Bildschirm­foto 2023-01-09 um 16 15 43" src="https://user-images.githubusercontent.com/122253264/211341916-1c9f5a1d-6a7e-4600-913e-c9fadcd565bb.png">
