### PR TITLE
If card is not available price is set to 0

### DIFF
--- a/scrapers.py
+++ b/scrapers.py
@@ -13,6 +13,8 @@ from scrapeAndCheck import *
 
 def CMSoupScraper(url, soup):
 	def priceToFloat(price):
+		if price == "None":
+			return 0
 		return round(float(price.replace(".","").replace(",",".").replace("€","")),3)
 
 	"""


### PR DESCRIPTION
When scraping a card that is not available some price parameters can be "None", which leads to an exception when converting string to float. This checks if price is "None" and returns 0 if true.
for example (as of now): https://www.cardmarket.com/de/Pokemon/Products/Singles/Team-Rocket/Dark-Alakazam-V1-TR1?language=3&minCondition=2&isSigned=N&isAltered=N&isFirstEd=N